### PR TITLE
changing quote type and removing extra quote in Example 5

### DIFF
--- a/doc_source/supported-manifest-file-format.md
+++ b/doc_source/supported-manifest-file-format.md
@@ -168,7 +168,7 @@ The following example uses the Amazon Redshift format to identify two JSON files
         }
     ],
     "globalUploadSettings": {
-        “format": “JSON""
+        "format": "JSON"
     }
 }
 ```


### PR DESCRIPTION
*Problem:*

When attempting to Copy the code from Example 5 it results in invalid JSON.  

*Description of changes:*

Changed the quote type and removed the additional quote to pass JSON validation when copying the example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
