### PR TITLE
Comma Typo for lookup index

### DIFF
--- a/doc_source/percentDifference-function.md
+++ b/doc_source/percentDifference-function.md
@@ -13,7 +13,7 @@ percentDifference
 (
      measure 
      ,[ sortorder_field ASC_or_DESC, ... ]  
-     ,lookup index,
+     ,lookup index
      ,[ partition_field, ... ] 
 )
 ```


### PR DESCRIPTION
*Issue #, if available:*
Extra comma typo

*Description of changes:*
Removed extra comma ',lookup index,' --> ',lookup index' as the comma is displayed on the next line at the front of ,[ partition_field, ... ]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
