### PR TITLE
Minor, remove extra paren from example calculation

### DIFF
--- a/doc_source/calculated-field-reference.md
+++ b/doc_source/calculated-field-reference.md
@@ -51,7 +51,7 @@ Because parenthesis are first in the order of operations, you can change the ord
 The following example uses multiple arithmetic operators to determine a sales total after discount\.
 
 ```
-(Quantity * Amount) - Discount)
+(Quantity * Amount) - Discount
 ```
 
 ### Example: \(=\) Equal<a name="operator-example-equal"></a>


### PR DESCRIPTION
Remove extra parenthesis.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
