### PR TITLE
Added another example for removing string characters from a string field

### DIFF
--- a/doc_source/rtrim-function.md
+++ b/doc_source/rtrim-function.md
@@ -30,3 +30,15 @@ For these field values, the following values are returned\.
 ```
 Seattle Store #14
 ```
+
+You can also remote specific characters from at the end of a string field. For example, assuming `customer.address` has the string value `Seatle Store #14`:
+
+```
+rtrim(customer.address, '#14')
+```
+
+And this will return\.
+
+```
+Seattle Store 
+```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added another example for `RTRIM`. You can actually remove trailing characters from a string field as well by concatenating a field with a string. This might also be useful incase you want to query for an address without a door number (as described in the example).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
