### PR TITLE
Adding character encoding UTF-8 to the sample page

### DIFF
--- a/doc_source/embedded-dashboards-example-html.md
+++ b/doc_source/embedded-dashboards-example-html.md
@@ -7,6 +7,7 @@ The following example shows the html you can use to display an embedded dashboar
 <html>
 
 <head>
+    <meta charset="UTF-8"> #Character encoding is required to display this page onto the browser. 
     <title>Basic Embed</title>
     <script type="text/javascript" src="https://public.end.point/embedded-dashboards-sdk.min.js"></script>
     <script type="text/javascript">


### PR DESCRIPTION
If the page is used at it is, there will be a character encoding error. I would suggest adding the following line: `<meta charset="UTF-8">`

*Issue #, if available:*

*Description of changes:*
Add `<meta charset="UTF-8">` as the first line within `<HEAD>` tag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
